### PR TITLE
Wg 42b delete exercise set

### DIFF
--- a/src/component/TableRow.tsx
+++ b/src/component/TableRow.tsx
@@ -1,5 +1,5 @@
-import React, {useContext} from 'react';
-import {StyleSheet, View} from 'react-native';
+import React, {useContext, useState} from 'react';
+import {StyleSheet} from 'react-native';
 import styled from 'styled-components/native';
 import {DataTable} from 'react-native-paper';
 import Icon from 'react-native-vector-icons/FontAwesome5';
@@ -21,7 +21,7 @@ const EditText = styled.TextInput`
   font-size: 12px;
   flex: 1;
   color: rgb(38, 38, 38);
-  background-color: 'rgb(169,169,169)';
+  background-color: 'rgb(200,200,200)';
 `;
 
 const WorkoutIcon = ({name}: {name: string}) => {
@@ -37,29 +37,24 @@ export default function TableRow({
   index: Number;
   workoutId: String;
 }) {
-  const {clickComplete, deleteSet} = useContext(UserContext);
+  const {clickComplete, deleteSet, editSet} = useContext(UserContext);
 
-  const [reps, onChangeReps] = React.useState('10');
-  const [weight, onChangeWeight] = React.useState('0');
-  const [isEditable, setIsEditable] = React.useState(false);
-
-  const editSet = () => {
-    isEditable ? setIsEditable(false) : setIsEditable(true);
-  };
+  const [reps, onChangeReps] = useState('10');
+  const [weight, onChangeWeight] = useState('0');
 
   return (
     <DataTable.Row>
       <DataTable.Cell style={styles.cell}>
         <ExerciseSetText>{row.Set}</ExerciseSetText>
       </DataTable.Cell>
-      {isEditable ? (
+      {row.Edit ? (
         <EditText value={reps} onChangeText={onChangeReps} placeholder={'0'} />
       ) : (
         <DataTable.Cell style={styles.cell}>
           <ExerciseSetText>{row.Reps}</ExerciseSetText>
         </DataTable.Cell>
       )}
-      {isEditable ? (
+      {row.Edit ? (
         <EditText
           value={weight}
           onChangeText={onChangeWeight}
@@ -77,8 +72,13 @@ export default function TableRow({
         </TouchableOpacity>
       </DataTable.Cell>
       <DataTable.Cell style={styles.cell}>
-        <TouchableOpacity onPress={editSet}>
-          <WorkoutIcon name="edit" />
+        <TouchableOpacity
+          onPress={() => editSet({row, index, workoutId, reps, weight})}>
+          {row.Edit ? (
+            <WorkoutIcon name="check" />
+          ) : (
+            <WorkoutIcon name="edit" />
+          )}
         </TouchableOpacity>
       </DataTable.Cell>
       <DataTable.Cell style={styles.cell}>

--- a/src/component/TableRow.tsx
+++ b/src/component/TableRow.tsx
@@ -26,9 +26,7 @@ export default function TableRow({
   index: Number;
   workoutId: String;
 }) {
-  const {clickComplete} = useContext(UserContext);
-
-  console.log('rowlalala', row);
+  const {clickComplete, deleteSet} = useContext(UserContext);
 
   return (
     <DataTable.Row>
@@ -53,7 +51,7 @@ export default function TableRow({
         </TouchableOpacity>
       </DataTable.Cell>
       <DataTable.Cell>
-        <TouchableOpacity>
+        <TouchableOpacity onPress={() => deleteSet({index, workoutId})}>
           <WorkoutIcon name="trash" />
         </TouchableOpacity>
       </DataTable.Cell>

--- a/src/component/TableRow.tsx
+++ b/src/component/TableRow.tsx
@@ -39,8 +39,36 @@ export default function TableRow({
 }) {
   const {clickComplete, deleteSet, editSet} = useContext(UserContext);
 
-  const [reps, onChangeReps] = useState('10');
-  const [weight, onChangeWeight] = useState('0');
+  const [reps, setReps] = useState('10');
+  const [weight, setWeight] = useState('0');
+
+  const onChangedReps = (text: string) => {
+    let newText = '';
+    let numbers = '0123456789';
+
+    for (var i = 0; i < text.length; i++) {
+      if (numbers.indexOf(text[i]) > -1) {
+        newText = newText + text[i];
+      } else {
+        alert('please enter numbers only');
+      }
+    }
+    setReps(newText);
+  };
+
+  const onChangedWeight = (text: string) => {
+    let newText = '';
+    let numbers = '0123456789';
+
+    for (let i = 0; i < text.length; i++) {
+      if (numbers.indexOf(text[i]) > -1) {
+        newText = newText + text[i];
+      } else {
+        alert('please enter numbers only');
+      }
+    }
+    setWeight(newText);
+  };
 
   return (
     <DataTable.Row>
@@ -48,7 +76,13 @@ export default function TableRow({
         <ExerciseSetText>{row.Set}</ExerciseSetText>
       </DataTable.Cell>
       {row.Edit ? (
-        <EditText value={reps} onChangeText={onChangeReps} placeholder={'0'} />
+        <EditText
+          value={reps}
+          keyboardType="numeric"
+          onChangeText={text => onChangedReps(text)}
+          placeholder={'0'}
+          maxLength={3}
+        />
       ) : (
         <DataTable.Cell style={styles.cell}>
           <ExerciseSetText>{row.Reps}</ExerciseSetText>
@@ -57,8 +91,10 @@ export default function TableRow({
       {row.Edit ? (
         <EditText
           value={weight}
-          onChangeText={onChangeWeight}
+          keyboardType="numeric"
+          onChangeText={text => onChangedWeight(text)}
           placeholder={'0'}
+          maxLength={3}
         />
       ) : (
         <DataTable.Cell style={styles.cell}>

--- a/src/component/TableRow.tsx
+++ b/src/component/TableRow.tsx
@@ -1,4 +1,5 @@
 import React, {useContext} from 'react';
+import {StyleSheet, View} from 'react-native';
 import styled from 'styled-components/native';
 import {DataTable} from 'react-native-paper';
 import Icon from 'react-native-vector-icons/FontAwesome5';
@@ -9,8 +10,18 @@ const ExerciseSetText = styled.Text`
   color: rgb(38, 38, 38);
   font-family: 'Montserrat-Regular';
   font-size: 12px;
-  text-align: center;
+  text-align: left;
   padding-bottom: 1px;
+`;
+
+const EditText = styled.TextInput`
+  padding-bottom: 1px;
+  text-align: center;
+  font-family: 'Montserrat-Regular';
+  font-size: 12px;
+  flex: 1;
+  color: rgb(38, 38, 38);
+  background-color: 'rgb(169,169,169)';
 `;
 
 const WorkoutIcon = ({name}: {name: string}) => {
@@ -28,29 +39,49 @@ export default function TableRow({
 }) {
   const {clickComplete, deleteSet} = useContext(UserContext);
 
+  const [reps, onChangeReps] = React.useState('10');
+  const [weight, onChangeWeight] = React.useState('0');
+  const [isEditable, setIsEditable] = React.useState(false);
+
+  const editSet = () => {
+    isEditable ? setIsEditable(false) : setIsEditable(true);
+  };
+
   return (
     <DataTable.Row>
-      <DataTable.Cell>
+      <DataTable.Cell style={styles.cell}>
         <ExerciseSetText>{row.Set}</ExerciseSetText>
       </DataTable.Cell>
-      <DataTable.Cell>
-        <ExerciseSetText>{row.Reps}</ExerciseSetText>
-      </DataTable.Cell>
-      <DataTable.Cell>
-        <ExerciseSetText>{row.Weight}</ExerciseSetText>
-      </DataTable.Cell>
-      <DataTable.Cell>
+      {isEditable ? (
+        <EditText value={reps} onChangeText={onChangeReps} placeholder={'0'} />
+      ) : (
+        <DataTable.Cell style={styles.cell}>
+          <ExerciseSetText>{row.Reps}</ExerciseSetText>
+        </DataTable.Cell>
+      )}
+      {isEditable ? (
+        <EditText
+          value={weight}
+          onChangeText={onChangeWeight}
+          placeholder={'0'}
+        />
+      ) : (
+        <DataTable.Cell style={styles.cell}>
+          <ExerciseSetText>{row.Weight}</ExerciseSetText>
+        </DataTable.Cell>
+      )}
+      <DataTable.Cell style={styles.cell}>
         <TouchableOpacity
           onPress={() => clickComplete({row, index, workoutId})}>
           <WorkoutIcon name={row.Completion} />
         </TouchableOpacity>
       </DataTable.Cell>
-      <DataTable.Cell>
-        <TouchableOpacity>
+      <DataTable.Cell style={styles.cell}>
+        <TouchableOpacity onPress={editSet}>
           <WorkoutIcon name="edit" />
         </TouchableOpacity>
       </DataTable.Cell>
-      <DataTable.Cell>
+      <DataTable.Cell style={styles.cell}>
         <TouchableOpacity onPress={() => deleteSet({index, workoutId})}>
           <WorkoutIcon name="trash" />
         </TouchableOpacity>
@@ -58,3 +89,10 @@ export default function TableRow({
     </DataTable.Row>
   );
 }
+
+const styles = StyleSheet.create({
+  cell: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});

--- a/src/component/TableRow.tsx
+++ b/src/component/TableRow.tsx
@@ -49,8 +49,6 @@ export default function TableRow({
     for (var i = 0; i < text.length; i++) {
       if (numbers.indexOf(text[i]) > -1) {
         newText = newText + text[i];
-      } else {
-        alert('please enter numbers only');
       }
     }
     setReps(newText);
@@ -63,66 +61,66 @@ export default function TableRow({
     for (let i = 0; i < text.length; i++) {
       if (numbers.indexOf(text[i]) > -1) {
         newText = newText + text[i];
-      } else {
-        alert('please enter numbers only');
       }
     }
     setWeight(newText);
   };
 
   return (
-    <DataTable.Row>
-      <DataTable.Cell style={styles.cell}>
-        <ExerciseSetText>{row.Set}</ExerciseSetText>
-      </DataTable.Cell>
-      {row.Edit ? (
-        <EditText
-          value={reps}
-          keyboardType="numeric"
-          onChangeText={text => onChangedReps(text)}
-          placeholder={'0'}
-          maxLength={3}
-        />
-      ) : (
+    <>
+      <DataTable.Row>
         <DataTable.Cell style={styles.cell}>
-          <ExerciseSetText>{row.Reps}</ExerciseSetText>
+          <ExerciseSetText>{row.Set}</ExerciseSetText>
         </DataTable.Cell>
-      )}
-      {row.Edit ? (
-        <EditText
-          value={weight}
-          keyboardType="numeric"
-          onChangeText={text => onChangedWeight(text)}
-          placeholder={'0'}
-          maxLength={3}
-        />
-      ) : (
+        {row.Edit ? (
+          <EditText
+            value={reps}
+            keyboardType="numeric"
+            onChangeText={text => onChangedReps(text)}
+            placeholder={'0'}
+            maxLength={3}
+          />
+        ) : (
+          <DataTable.Cell style={styles.cell}>
+            <ExerciseSetText>{row.Reps}</ExerciseSetText>
+          </DataTable.Cell>
+        )}
+        {row.Edit ? (
+          <EditText
+            value={weight}
+            keyboardType="numeric"
+            onChangeText={text => onChangedWeight(text)}
+            placeholder={'0'}
+            maxLength={3}
+          />
+        ) : (
+          <DataTable.Cell style={styles.cell}>
+            <ExerciseSetText>{row.Weight}</ExerciseSetText>
+          </DataTable.Cell>
+        )}
         <DataTable.Cell style={styles.cell}>
-          <ExerciseSetText>{row.Weight}</ExerciseSetText>
+          <TouchableOpacity
+            onPress={() => clickComplete({row, index, workoutId})}>
+            <WorkoutIcon name={row.Completion} />
+          </TouchableOpacity>
         </DataTable.Cell>
-      )}
-      <DataTable.Cell style={styles.cell}>
-        <TouchableOpacity
-          onPress={() => clickComplete({row, index, workoutId})}>
-          <WorkoutIcon name={row.Completion} />
-        </TouchableOpacity>
-      </DataTable.Cell>
-      <DataTable.Cell style={styles.cell}>
-        <TouchableOpacity
-          onPress={() => editSet({row, index, workoutId, reps, weight})}>
-          {row.Edit ? (
-            <WorkoutIcon name="check" />
-          ) : (
-            <WorkoutIcon name="edit" />
-          )}
-        </TouchableOpacity>
-      </DataTable.Cell>
-      <DataTable.Cell style={styles.cell}>
-        <TouchableOpacity onPress={() => deleteSet({index, workoutId})}>
-          <WorkoutIcon name="trash" />
-        </TouchableOpacity>
-      </DataTable.Cell>
-    </DataTable.Row>
+        <DataTable.Cell style={styles.cell}>
+          <TouchableOpacity
+            onPress={() => editSet({row, index, workoutId, reps, weight})}>
+            {row.Edit ? (
+              <WorkoutIcon name="check" />
+            ) : (
+              <WorkoutIcon name="edit" />
+            )}
+          </TouchableOpacity>
+        </DataTable.Cell>
+        <DataTable.Cell style={styles.cell}>
+          <TouchableOpacity onPress={() => deleteSet({index, workoutId})}>
+            <WorkoutIcon name="trash" />
+          </TouchableOpacity>
+        </DataTable.Cell>
+      </DataTable.Row>
+    </>
   );
 }
 

--- a/src/component/TableRow.tsx
+++ b/src/component/TableRow.tsx
@@ -6,22 +6,22 @@ import Icon from 'react-native-vector-icons/FontAwesome5';
 import {TouchableOpacity} from 'react-native-gesture-handler';
 import {UserContext} from '../context/User.Context';
 
+const EditText = styled.TextInput`
+  background-color: 'rgb(200,200,200)';
+  color: rgb(38, 38, 38);
+  flex: 1;
+  font-family: 'Montserrat-Regular';
+  font-size: 12px;
+  padding-bottom: 1px;
+  text-align: center;
+`;
+
 const ExerciseSetText = styled.Text`
   color: rgb(38, 38, 38);
   font-family: 'Montserrat-Regular';
   font-size: 12px;
+  padding-bottom: 1px;
   text-align: left;
-  padding-bottom: 1px;
-`;
-
-const EditText = styled.TextInput`
-  padding-bottom: 1px;
-  text-align: center;
-  font-family: 'Montserrat-Regular';
-  font-size: 12px;
-  flex: 1;
-  color: rgb(38, 38, 38);
-  background-color: 'rgb(200,200,200)';
 `;
 
 const WorkoutIcon = ({name}: {name: string}) => {
@@ -43,27 +43,17 @@ export default function TableRow({
   const [weight, setWeight] = useState('0');
 
   const onChangedReps = (text: string) => {
-    let newText = '';
-    let numbers = '0123456789';
+    isNaN(Number(text)) || text.includes('.')
+      ? (text = text.substr(0, text.length - 1))
+      : text;
 
-    for (var i = 0; i < text.length; i++) {
-      if (numbers.indexOf(text[i]) > -1) {
-        newText = newText + text[i];
-      }
-    }
-    setReps(newText);
+    setReps(text);
   };
 
   const onChangedWeight = (text: string) => {
-    let newText = '';
-    let numbers = '0123456789';
+    isNaN(Number(text)) ? (text = text.substr(0, text.length - 1)) : text;
 
-    for (let i = 0; i < text.length; i++) {
-      if (numbers.indexOf(text[i]) > -1) {
-        newText = newText + text[i];
-      }
-    }
-    setWeight(newText);
+    setWeight(text);
   };
 
   return (
@@ -78,7 +68,7 @@ export default function TableRow({
             keyboardType="numeric"
             onChangeText={text => onChangedReps(text)}
             placeholder={'0'}
-            maxLength={3}
+            maxLength={755}
           />
         ) : (
           <DataTable.Cell style={styles.cell}>
@@ -91,7 +81,7 @@ export default function TableRow({
             keyboardType="numeric"
             onChangeText={text => onChangedWeight(text)}
             placeholder={'0'}
-            maxLength={3}
+            maxLength={7}
           />
         ) : (
           <DataTable.Cell style={styles.cell}>

--- a/src/component/WorkoutExercise.tsx
+++ b/src/component/WorkoutExercise.tsx
@@ -1,5 +1,6 @@
-import React, {ReactNode, useContext, useState} from 'react';
+import React, {ReactNode, useContext} from 'react';
 import {SequenceItem, BorderBottom} from '../../types/data';
+import {StyleSheet} from 'react-native';
 import styled from 'styled-components/native';
 import Popover from 'react-native-popover-view';
 import {UserContext} from '../context/User.Context';
@@ -8,7 +9,6 @@ import PlannerIcon from 'react-native-vector-icons/FontAwesome5';
 import AddIcon from 'react-native-vector-icons/FontAwesome5';
 import ExerciseData from './ExerciseData';
 import {DataTable} from 'react-native-paper';
-import exerciseSet from '../utils/exerciseset';
 
 const AddText = styled.Text`
   color: rgb(38, 38, 38);
@@ -36,7 +36,7 @@ const ExerciseSetText = styled.Text`
   color: rgb(38, 38, 38);
   font-family: 'Montserrat-Regular';
   font-size: 12px;
-  text-align: left;
+  text-align: center;
   padding-bottom: 1px;
 `;
 const ExerciseTitleView = styled.View`
@@ -85,6 +85,8 @@ export default function WorkoutExercise({
 }) {
   const {muscleGroup, workout, addSet} = useContext(UserContext);
 
+  const headers = ['Set', 'Reps', 'Weight', 'Done', 'Edit', 'Delete'];
+
   return (
     <ExerciseView borderBottom={isLastItem ? 1 : 0}>
       <ExerciseTitleView>
@@ -129,26 +131,15 @@ export default function WorkoutExercise({
           </Popover>
         )}
       </ExerciseInfoView>
-      <DataTable style={{marginLeft: 20}}>
+      <DataTable>
         <DataTable.Header>
-          <DataTable.Title>
-            <ExerciseSetText>Set</ExerciseSetText>
-          </DataTable.Title>
-          <DataTable.Title>
-            <ExerciseSetText>Reps</ExerciseSetText>
-          </DataTable.Title>
-          <DataTable.Title>
-            <ExerciseSetText>Weight</ExerciseSetText>
-          </DataTable.Title>
-          <DataTable.Title>
-            <ExerciseSetText>Done</ExerciseSetText>
-          </DataTable.Title>
-          <DataTable.Title>
-            <ExerciseSetText>Edit</ExerciseSetText>
-          </DataTable.Title>
-          <DataTable.Title>
-            <ExerciseSetText>Delete</ExerciseSetText>
-          </DataTable.Title>
+          {headers.map((header: String, index: Number) => {
+            return (
+              <DataTable.Title style={styles.title} key={`${index}`}>
+                <ExerciseSetText>{header}</ExerciseSetText>
+              </DataTable.Title>
+            );
+          })}
         </DataTable.Header>
         <ExerciseData item={workout[+workoutId]} workoutId={workoutId} />
       </DataTable>
@@ -159,3 +150,10 @@ export default function WorkoutExercise({
     </ExerciseView>
   );
 }
+
+const styles = StyleSheet.create({
+  title: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+});

--- a/src/context/User.Context.js
+++ b/src/context/User.Context.js
@@ -81,13 +81,6 @@ const UserProvider = ({children}) => {
   const defaultExercises = data => {
     let allExercises = {};
     data.map((_, index) => (allExercises[data[index].id] = [...exerciseSet]));
-    // for (let i = 0; i < data.length; i++) {
-    //   // array referencing. You were doing this
-    //   // allExercises[data[i].id] = exerciseSet so this basically means you are referencing to the SAME
-    //   // array but you actually want to make a copy of the array
-    //   // that's why when you update one, you update them all. It was a pointer reference
-    //   allExercises[data[i].id] = [...exerciseSet];
-    // }
     setWorkout(allExercises);
   };
 
@@ -111,7 +104,15 @@ const UserProvider = ({children}) => {
       Completion: 'circle',
     };
     tempWorkout[workoutId].push(newSet);
-    console.log(tempWorkout[workoutId]);
+    setWorkout(tempWorkout);
+  };
+
+  const deleteSet = ({index, workoutId}) => {
+    const tempWorkout = {...workout};
+    tempWorkout[workoutId].splice(index, 1);
+    tempWorkout[workoutId].map((set, index) => {
+      set.Set = index + 1;
+    });
     setWorkout(tempWorkout);
   };
 
@@ -179,6 +180,7 @@ const UserProvider = ({children}) => {
           workout,
           clickComplete,
           addSet,
+          deleteSet,
         }}>
         {children}
       </UserContext.Provider>

--- a/src/context/User.Context.js
+++ b/src/context/User.Context.js
@@ -99,12 +99,20 @@ const UserProvider = ({children}) => {
   // check whether user input is a number - if not, do not allow state changes
   // and display an error message
 
+  // add logic to remove trailing zeroes
+
   const editSet = ({row, index, workoutId, reps, weight}) => {
     if (reps === '') {
       reps = '0';
     }
+    if (reps.slice(-1) === '.') {
+      reps = reps.replace('.', '');
+    }
     if (weight === '') {
       weight = '0';
+    }
+    if (weight.slice(-1) === '.') {
+      weight = weight.replace('.', '');
     }
     const tempWorkout = {...workout};
     const editRow =

--- a/src/context/User.Context.js
+++ b/src/context/User.Context.js
@@ -95,7 +95,17 @@ const UserProvider = ({children}) => {
     setWorkout(tempWorkout);
   };
 
+  // need to add error handling - before setting reps and weight to tempworkout,
+  // check whether user input is a number - if not, do not allow state changes
+  // and display an error message
+
   const editSet = ({row, index, workoutId, reps, weight}) => {
+    if (reps === '') {
+      reps = '0';
+    }
+    if (weight === '') {
+      weight = '0';
+    }
     const tempWorkout = {...workout};
     const editRow =
       row.Edit === true

--- a/src/context/User.Context.js
+++ b/src/context/User.Context.js
@@ -16,6 +16,7 @@ const UserProvider = ({children}) => {
   const [numberOfExercises, setNumberOfExercises] = useState('0');
   const [exerciseData, setExerciseData] = useState([]);
   const [workout, setWorkout] = useState({});
+  const [isEditable, setIsEditable] = useState(false);
 
   const checkOnboarding = async () => {
     try {
@@ -94,6 +95,16 @@ const UserProvider = ({children}) => {
     setWorkout(tempWorkout);
   };
 
+  const editSet = ({row, index, workoutId, reps, weight}) => {
+    const tempWorkout = {...workout};
+    const editRow =
+      row.Edit === true
+        ? {...row, Edit: false, Reps: reps, Weight: weight}
+        : {...row, Edit: true};
+    tempWorkout[workoutId][index] = editRow;
+    setWorkout(tempWorkout);
+  };
+
   const addSet = ({workoutId}) => {
     const tempWorkout = {...workout};
     const setNumber = tempWorkout[workoutId].length + 1;
@@ -141,18 +152,6 @@ const UserProvider = ({children}) => {
     }
   };
 
-  // Need to create user context state for entireExercise (user workout)
-  // key value pair is going to be exercise id (item.id) and generic exerciseSet
-  // when user adds to the exercise set, identify the correct exercise set
-  // based on exercise id and use spread operator to add a new set to that
-  // exercise set only. This way state will persist if user navigates away
-  // and will be available when user wants to save to favourites
-  // const entireExercise = {
-  //   1: exerciseSet,
-  //   2: exerciseSet,
-  //   3: exerciseSet,
-  // };
-
   useEffect(() => {
     checkOnboarding();
     fetchMuscleGroup();
@@ -181,6 +180,9 @@ const UserProvider = ({children}) => {
           clickComplete,
           addSet,
           deleteSet,
+          isEditable,
+          setIsEditable,
+          editSet,
         }}>
         {children}
       </UserContext.Provider>


### PR DESCRIPTION
Added functionality to edit and delete buttons to allow users to modify their workouts and save the changes in user context.

JIRA ticket: https://lhl-midterm-ecommerce.atlassian.net/browse/WG-42

Screenshots:

User has clicked edit button -> edit icon changes to confirm changes icon (check mark), editable fields are highlighted

![Screen Shot 2023-05-08 at 4 03 14 PM](https://user-images.githubusercontent.com/108088437/236956001-d15ce319-4113-4a32-bdea-01a7f6d7dc0a.png)

User edits highlighted fields with new values

![Screen Shot 2023-05-08 at 4 03 25 PM](https://user-images.githubusercontent.com/108088437/236956110-410eb507-d431-4524-bb81-722575fe1ab9.png)

User confirms changes and saves new values to state

![Screen Shot 2023-05-08 at 4 03 30 PM](https://user-images.githubusercontent.com/108088437/236956183-9a0157c6-e5d7-43aa-a4ff-133f33a4103e.png)

User deletes the recently edited row

![Screen Shot 2023-05-08 at 4 03 36 PM](https://user-images.githubusercontent.com/108088437/236956221-a2bf33dd-7270-4e3f-bcac-33eb769ee3fb.png)
