### PR TITLE
Wg 44 overwrite favourites and favourite title char limit

### DIFF
--- a/src/context/User.Context.js
+++ b/src/context/User.Context.js
@@ -140,10 +140,6 @@ const UserProvider = ({children}) => {
     setFavouriteWorkoutData(tempWorkout);
   };
 
-  // need to add error handling - before setting reps and weight to tempworkout,
-  // check whether user input is a number - if not, do not allow state changes
-  // and display an error message
-
   // add logic to remove trailing zeroes
 
   const editSet = ({row, index, workoutId, reps, weight}) => {
@@ -246,12 +242,7 @@ const UserProvider = ({children}) => {
     storeWorkoutData(tempWorkout);
   };
 
-  // reset state related to selected muscles, equipment, reps, workout, etc
-  // then navigate back to home screen
-
   const clearWorkout = ({navigation}) => {
-    // unable to update state within this function directly - need to research another way
-    // to revert to initial state for muscles, equipment, reps and workout
     setLoading(true);
     setWorkout({});
     setSelectedMuscles([]);

--- a/src/screens/WorkoutsScreen.tsx
+++ b/src/screens/WorkoutsScreen.tsx
@@ -95,6 +95,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
   const [workoutSaved, setWorkoutSaved] = useState(false);
   const [addFavouritesVisible, setAddFavouritesVisible] = useState(true);
   const [minCharWarning, setMinCharWarning] = useState(false);
+  const [maxCharWarning, setMaxCharWarning] = useState(false);
   const [text, onChangeText] = useState('');
   const {exerciseData, clearWorkout, workout, title, setTitle} =
     useContext(UserContext);
@@ -103,10 +104,12 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
   // need to retrieve number of workouts from UserContext
 
   const onConfirm = async () => {
-    setTitle(text);
     if (text.length < 3) {
       setMinCharWarning(true);
-    } else if (text.length >= 3) {
+    } else if (text.length >= 30) {
+      setMaxCharWarning(true);
+    } else if (text.length >= 3 && text.length < 30) {
+      setTitle(text);
       try {
         let values = await getFavouriteTokens();
         if (values.length >= 3) {
@@ -147,13 +150,16 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
 
   const modalPopup = () => {
     const titleText = text || 'My workout';
-    setTitle(titleText);
+    if (titleText.length >= 3 && titleText.length < 30) {
+      setTitle(titleText);
+    }
     setModalVisible(true);
   };
 
   const onCancel = () => {
     setModalVisible(false);
     setMinCharWarning(false);
+    setMaxCharWarning(false);
   };
 
   const getFavouriteTokens = async () => {
@@ -275,6 +281,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
               <ButtonText>Cancel</ButtonText>
             </Button>
             {minCharWarning && <Warning>{warnings[3]}</Warning>}
+            {maxCharWarning && <Warning>{warnings[4]}</Warning>}
           </InnerModalView>
         </OuterModalView>
       </Modal>

--- a/src/screens/WorkoutsScreen.tsx
+++ b/src/screens/WorkoutsScreen.tsx
@@ -100,9 +100,6 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
   const {exerciseData, clearWorkout, workout, title, setTitle} =
     useContext(UserContext);
 
-  // add code to onConfirm function to warn user if there are already max number of workouts
-  // need to retrieve number of workouts from UserContext
-
   const onConfirm = async () => {
     if (text.length < 3) {
       setMinCharWarning(true);
@@ -223,8 +220,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
       let values = await getFavouriteTokens();
       let updatedFavourites = [...values];
       // remove oldest workout token from array if there are too many favourite workouts
-      // for now set to three for simplicity
-      if (updatedFavourites.length >= 3) {
+      if (updatedFavourites.length >= 10) {
         updatedFavourites.shift();
         // also need to remove excess exerise list/workouts
       }
@@ -256,11 +252,6 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
       // saving error
     }
   };
-
-  // 1. confirm with user that oldest workout will be overwritten and provide option to abort
-  // in case max number of workouts has been reached
-  // 2. add limit to number of characters and conditionally render warning message,
-  // prevent user from saving workout name that is too long
 
   return (
     <ContainerWrapper>

--- a/src/screens/WorkoutsScreen.tsx
+++ b/src/screens/WorkoutsScreen.tsx
@@ -109,7 +109,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
       setTitle(text);
       try {
         let values = await getFavouriteTokens();
-        if (values.length >= 3) {
+        if (values.length >= 10) {
           createTwoButtonAlert();
         } else {
           try {
@@ -204,7 +204,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
     try {
       let values = await getWorkoutNames();
       let updatedWorkoutNames = [...values];
-      if (updatedWorkoutNames.length >= 3) {
+      if (updatedWorkoutNames.length >= 10) {
         updatedWorkoutNames.shift();
       }
 
@@ -222,7 +222,6 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
       // remove oldest workout token from array if there are too many favourite workouts
       if (updatedFavourites.length >= 10) {
         updatedFavourites.shift();
-        // also need to remove excess exerise list/workouts
       }
       // add new favourite workout token to the list
       updatedFavourites.push(newFavouriteToken);
@@ -323,11 +322,11 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
         )}
       />
       <ButtonWrapper>
-        {/* {addFavouritesVisible && ( */}
-        <Button onPress={modalPopup}>
-          <ButtonText>Add to favourites</ButtonText>
-        </Button>
-        {/* )} */}
+        {addFavouritesVisible && (
+          <Button onPress={modalPopup}>
+            <ButtonText>Add to favourites</ButtonText>
+          </Button>
+        )}
         <Button
           onPress={() => {
             clearWorkout({navigation});

--- a/src/screens/WorkoutsScreen.tsx
+++ b/src/screens/WorkoutsScreen.tsx
@@ -94,17 +94,16 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
   const [modalVisible, setModalVisible] = useState(false);
   const [workoutSaved, setWorkoutSaved] = useState(false);
   const [addFavouritesVisible, setAddFavouritesVisible] = useState(true);
-  const [minCharWarning, setMinCharWarning] = useState(false);
-  const [maxCharWarning, setMaxCharWarning] = useState(false);
+  const [warning, setWarning] = useState('');
   const [text, onChangeText] = useState('');
   const {exerciseData, clearWorkout, workout, title, setTitle} =
     useContext(UserContext);
 
   const onConfirm = async () => {
     if (text.length < 3) {
-      setMinCharWarning(true);
+      setWarning('3');
     } else if (text.length >= 20) {
-      setMaxCharWarning(true);
+      setWarning('4');
     } else if (text.length >= 3 && text.length < 20) {
       setTitle(text);
       try {
@@ -163,8 +162,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
 
   const onCancel = () => {
     setModalVisible(false);
-    setMinCharWarning(false);
-    setMaxCharWarning(false);
+    setWarning('');
   };
 
   const getFavouriteTokens = async () => {
@@ -278,8 +276,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
             <Button onPress={onCancel}>
               <ButtonText>Cancel</ButtonText>
             </Button>
-            {minCharWarning && <Warning>{warnings[3]}</Warning>}
-            {maxCharWarning && <Warning>{warnings[4]}</Warning>}
+            {warning && <Warning>{warnings[warning]}</Warning>}
           </InnerModalView>
         </OuterModalView>
       </Modal>

--- a/src/screens/WorkoutsScreen.tsx
+++ b/src/screens/WorkoutsScreen.tsx
@@ -106,9 +106,9 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
   const onConfirm = async () => {
     if (text.length < 3) {
       setMinCharWarning(true);
-    } else if (text.length >= 30) {
+    } else if (text.length >= 20) {
       setMaxCharWarning(true);
-    } else if (text.length >= 3 && text.length < 30) {
+    } else if (text.length >= 3 && text.length < 20) {
       setTitle(text);
       try {
         let values = await getFavouriteTokens();
@@ -139,7 +139,15 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
       'Max Favourites Reached',
       'Ok to overwrite oldest favourite workout?',
       [
-        {text: 'OK', onPress: () => console.log('OK Pressed')},
+        {
+          text: 'OK',
+          onPress: async () => {
+            await saveToken();
+            setModalVisible(false);
+            setWorkoutSaved(true);
+            setAddFavouritesVisible(false);
+          },
+        },
         {
           text: 'Cancel',
           onPress: () => console.log('Cancel Pressed'),
@@ -150,7 +158,7 @@ export default function WorkoutsScreen({navigation}: NativeStackHeaderProps) {
 
   const modalPopup = () => {
     const titleText = text || 'My workout';
-    if (titleText.length >= 3 && titleText.length < 30) {
+    if (titleText.length >= 3 && titleText.length < 20) {
       setTitle(titleText);
     }
     setModalVisible(true);

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -2,6 +2,7 @@ const warnings = {
   '0': 'Please select at least one muscle group',
   '1': 'Please indicate what equipment you have available',
   '2': 'Please enter a valid number of exercises',
+  '3': 'Please enter at least three characters',
 };
 
 export default warnings;

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -3,6 +3,7 @@ const warnings = {
   '1': 'Please indicate what equipment you have available',
   '2': 'Please enter a valid number of exercises',
   '3': 'Please enter at least three characters',
+  '4': 'Please enter less than 30 characters',
 };
 
 export default warnings;

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -1,4 +1,8 @@
-const warnings = {
+interface ObjectType {
+  [key: string]: string;
+}
+
+const warnings: ObjectType = {
   '0': 'Please select at least one muscle group',
   '1': 'Please indicate what equipment you have available',
   '2': 'Please enter a valid number of exercises',

--- a/src/utils/warnings.ts
+++ b/src/utils/warnings.ts
@@ -3,7 +3,7 @@ const warnings = {
   '1': 'Please indicate what equipment you have available',
   '2': 'Please enter a valid number of exercises',
   '3': 'Please enter at least three characters',
-  '4': 'Please enter less than 30 characters',
+  '4': 'Please enter less than 20 characters',
 };
 
 export default warnings;


### PR DESCRIPTION
Add warning messages that pop up when user does not meet required characters for favourite workout title (min 3 and less than 20) when attempting to create new favourite. Also used iOS Alert to confirm user is ok to delete oldest workout when max number of favourite workouts has been reached.

JIRA ticket: https://lhl-midterm-ecommerce.atlassian.net/browse/WG-44

Screenshots

Min char warning

![Screen Shot 2023-06-26 at 10 35 07 PM](https://github.com/chrismcanulty/WorkoutGenerator/assets/108088437/67756c2d-0d84-46ac-8c85-13d0dd354b91)

User confirm ok to delete oldest workout

![Screen Shot 2023-06-26 at 10 35 26 PM](https://github.com/chrismcanulty/WorkoutGenerator/assets/108088437/df38f220-7dbe-4350-982b-48c5ec762bce)

Completion modal when new favourite is successfully saved

![Screen Shot 2023-06-26 at 10 35 34 PM](https://github.com/chrismcanulty/WorkoutGenerator/assets/108088437/12979462-1967-49a2-99bd-f9650eea2d3c)
